### PR TITLE
Fix out-of-date JBoss Maven repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <repository>
             <id>jboss repository</id>
             <name>JBoss Repository for Maven</name>
-            <url>http://repository.jboss.org/maven2/</url>
+            <url>https://repository.jboss.org/nexus/content/repositories/releases/</url>
             <layout>default</layout>
         </repository>
     </repositories>


### PR DESCRIPTION
Hello.

This fixes an out-of-date JBoss Maven repository URL in the pom.
