### PR TITLE
Remove reference to atomikos Maven repository

### DIFF
--- a/cosmo/pom.xml
+++ b/cosmo/pom.xml
@@ -40,10 +40,6 @@
 	</properties>
 	
 	<repositories>
-		<repository>
-			<id>atomikos</id>
-			<url>http://repo.atomikos.com</url>
-		</repository>
 		<!-- hibernate -->
 		<repository>
 			<id>nexus-jboss</id>


### PR DESCRIPTION
The atomikos repository is not needed by Cosmo, and is causing build failures in Cosmo and Ecco because the atomikos repository is no longer accessible to the general public.

(The symptom is that you will sometimes get 401 Not Authorized errors when Maven tries to download dependencies for Cosmo or Ecco, which will cause the build to fail).
